### PR TITLE
fix ES6 import example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const ws = require("isomorphic-ws");
 or
 
 ```javascript
-import simpleDDP from 'simpleDDP'; // ES6
+import simpleDDP from 'simpleddp'; // ES6
 import ws from 'isomorphic-ws';
 ```
 


### PR DESCRIPTION
Using different case in the import and the directory in node_modules can lead to nasty failures on file systems that differentiate between cases. I had code that was working fine on my mac but failing on a linux server with docker. Using the same lower case as the npm package does fixed it.